### PR TITLE
Ender lilies: Feature add spirit selection

### DIFF
--- a/worlds/enderlilies/Options.py
+++ b/worlds/enderlilies/Options.py
@@ -1,0 +1,60 @@
+from typing import Dict, FrozenSet, Union
+from Options import Choice, Option, Toggle
+from BaseClasses import MultiWorld
+
+
+class ShuffleSlots(Toggle):
+    display_name = "Shuffle Slots"
+
+class ShuffleBGM(Toggle):
+    display_name = "Shuffle Background Music"
+
+class ShuffleEnemies(Toggle):
+    display_name = "Shuffle Enemies"
+
+class NewGamePlus(Toggle):
+    display_name = "New Game Plus"
+
+class ForceAncientSouls(Toggle):
+    display_name = "Ancient Souls on starting spirit"
+
+class MiniBossIncrementsChapter(Toggle):
+    display_name = "Sub Spirits Increment Chapter"
+
+class ShuffleUpgrades(Toggle):
+    display_name = "Shuffle Upgrades"
+
+class StartingSpirit(Choice):
+    """Defines which spirit you might start with. The starting spirit has infinite usage. Default option is Umbral Knight.
+
+    Vanilla: Umbral knight.
+    Main: One of the main spirit (Gerrod, Silva, Julius, Ulv, Eleine, Hoenir, Faden, Siegrid
+    Any: Any of the spirits.
+    None: You will receive an item at the start but it can from any world.
+        Warning: the logic currently assumes that you start with a spirit. It might make a world impossible. """
+    display_name = "Starting spirits"
+    option_vanilla = 0
+    option_main = 1
+    option_any = 2
+    default = option_vanilla
+
+el_options: Dict[str, type(Option)] = {
+    # # Not added since not sure if the client can read it right now.
+    # "shuffle_slots": ShuffleSlots,
+    # "shuffle_bgm": ShuffleBGM,
+    # "shuffle_enemies": ShuffleEnemies,
+    # "new_game_plus": NewGamePlus,
+    # "force_ancient_souls": ForceAncientSouls,
+    # "mini_boss_incrememnts_chapter": MiniBossIncrementsChapter,
+    # "shuffle_upgrades": ShuffleUpgrades,
+    "starting_spirit": StartingSpirit,
+}
+
+
+def get_option_value(multiworld: MultiWorld, player: int, name: str) -> Union[int,  FrozenSet]:
+    if multiworld is None:
+        return el_options[name].default
+
+    player_option = getattr(multiworld, name)[player]
+
+    return player_option.value

--- a/worlds/enderlilies/Rules.py
+++ b/worlds/enderlilies/Rules.py
@@ -1,7 +1,6 @@
 from typing import Dict, Tuple
 from worlds.generic.Rules import CollectionRule, ItemRule
 from .Names import names as el
-from .Options import get_option_value
 
 def get_rules(m, p : int) -> Tuple[Dict[str, CollectionRule], Dict[str, ItemRule]]: 
 
@@ -777,18 +776,7 @@ def get_rules(m, p : int) -> Tuple[Dict[str, CollectionRule], Dict[str, ItemRule
 		'starting_weapon'                                                         : lambda s : True,
 	}
 
-	val = get_option_value(m, p, "starting_spirit")
-	if val == 0: 
-		start_item_rule = lambda item : item.player == p and item.name == 'Spirit.s5000'
-	elif val == 1: 
-		start_item_rule = lambda item : item.player == p and item.name.startswith('Spirit.s5')
-	elif val == 2: 
-		start_item_rule = lambda item : item.player == p and item.name.startswith('Spirit.')
-	elif val == 3: 
-		start_item_rule = lambda s : True
-
 	items_rules : Dict[str, ItemRule] = {
-		'starting_weapon' : start_item_rule,
 	}
 
 	return (locations_rules, items_rules)

--- a/worlds/enderlilies/Rules.py
+++ b/worlds/enderlilies/Rules.py
@@ -2,7 +2,7 @@ from typing import Dict, Tuple
 from worlds.generic.Rules import CollectionRule, ItemRule
 from .Names import names as el
 
-def get_rules(m, p : int) -> Tuple[Dict[str, CollectionRule], Dict[str, ItemRule]]: 
+def get_rules(p : int) -> Tuple[Dict[str, CollectionRule], Dict[str, ItemRule]]: 
 
 	macros : Dict[str, CollectionRule] = {
 		'3LEDGE'      : lambda s : s.has(el['djump'], p) and s.has(el['silva'], p) and s.has(el['champion'], p),

--- a/worlds/enderlilies/Rules.py
+++ b/worlds/enderlilies/Rules.py
@@ -1,8 +1,9 @@
 from typing import Dict, Tuple
 from worlds.generic.Rules import CollectionRule, ItemRule
 from .Names import names as el
+from .Options import get_option_value
 
-def get_rules(p : int) -> Tuple[Dict[str, CollectionRule], Dict[str, ItemRule]]: 
+def get_rules(m, p : int) -> Tuple[Dict[str, CollectionRule], Dict[str, ItemRule]]: 
 
 	macros : Dict[str, CollectionRule] = {
 		'3LEDGE'      : lambda s : s.has(el['djump'], p) and s.has(el['silva'], p) and s.has(el['champion'], p),
@@ -776,8 +777,18 @@ def get_rules(p : int) -> Tuple[Dict[str, CollectionRule], Dict[str, ItemRule]]:
 		'starting_weapon'                                                         : lambda s : True,
 	}
 
+	val = get_option_value(m, p, "starting_spirit")
+	if val == 0: 
+		start_item_rule = lambda item : item.player == p and item.name == 'Spirit.s5000'
+	elif val == 1: 
+		start_item_rule = lambda item : item.player == p and item.name.startswith('Spirit.s5')
+	elif val == 2: 
+		start_item_rule = lambda item : item.player == p and item.name.startswith('Spirit.')
+	elif val == 3: 
+		start_item_rule = lambda s : True
+
 	items_rules : Dict[str, ItemRule] = {
-		'starting_weapon' : lambda item : item.player == p and item.name.startswith('Spirit.'),
+		'starting_weapon' : start_item_rule,
 	}
 
 	return (locations_rules, items_rules)

--- a/worlds/enderlilies/__init__.py
+++ b/worlds/enderlilies/__init__.py
@@ -10,6 +10,7 @@ from .Items import items
 from .Locations import locations
 from .Rules import get_rules
 from .Names import names as el
+from .Options import el_options
 
 ENDERLILIES = "Ender Lilies"
 
@@ -24,6 +25,7 @@ class EnderLiliesWorld(World):
     Ender Lilies: QUIETUS OF THE KNIGHTS
     """
     game                = ENDERLILIES
+    option_definitions = el_options
     location_name_to_id = { name: data.address for name, data in locations.items() }
     item_name_to_id     = { name: data.code for name, data in items.items() }
 
@@ -55,7 +57,7 @@ class EnderLiliesWorld(World):
 
 
     def set_rules(self) -> None:
-        locations_rules, items_rules = get_rules(self.player)
+        locations_rules, items_rules = get_rules(self.multiworld, self.player)
         player = self.player        
 
         can_contain_map = lambda item : item.player == player and item.name.startswith('Map.')

--- a/worlds/enderlilies/__init__.py
+++ b/worlds/enderlilies/__init__.py
@@ -60,7 +60,7 @@ class EnderLiliesWorld(World):
 
 
     def set_rules(self) -> None:
-        locations_rules, items_rules = get_rules(self.multiworld, self.player)
+        locations_rules, items_rules = get_rules(self.player)
         player = self.player        
 
         can_contain_map = lambda item : item.player == player and item.name.startswith('Map.')

--- a/worlds/enderlilies/__init__.py
+++ b/worlds/enderlilies/__init__.py
@@ -106,8 +106,6 @@ def assign_starting_item(multiworld: MultiWorld, player: int, items) -> str:
         spirit_list = [x for x in list(items.keys()) if x.startswith('Spirit.s5')]
     elif val == 2: 
         spirit_list = [x for x in list(items.keys()) if x.startswith('Spirit.s')]
-    elif val == 3: 
-        return None
 
     avail_spirit = sorted(item for item in spirit_list if item not in non_local_items)
     if not avail_spirit:


### PR DESCRIPTION
## What is this fixing or adding?
Add an option to select which group of spirit we can start with. Also, the selection is now a little bit sooner than the prior implementation since it is a "local" decision. 

## How was this tested?
Each options was generated four times and a valid spirit was confirmed in the spoiler each time.
For each options, I confirmed two times (among the four) that the spirits shown in the spoiler was indeed the starting spirit. 

## If this makes graphical changes, please attach screenshots.
None.


Note: While I took VGFreak options.py, most of its options are probably not working with the client out of the box. As such, I put them in comments for now.