### PR TITLE
AP-side victory options for EL

### DIFF
--- a/worlds/enderlilies/Locations.py
+++ b/worlds/enderlilies/Locations.py
@@ -766,4 +766,7 @@ locations : Dict[str, LocationData]= {
 	'Village_15_GAMEPLAY.BP_WorldTravelVolume_2'                              : LocationData(address=None, content='Map.map_village_09.2'),
 	'Village_15_GAMEPLAY.BP_WorldTravelVolume2_5'                             : LocationData(address=None, content='Map.map_fort_01.V15'),
 	'Village_16_GAMEPLAY.BP_WorldTravelVolume3'                               : LocationData(address=None, content='Map.map_village_12.16'),
+    'Benevolence'                                                             : LocationData(address=None, content='Ending_A'),
+    'Journeys_End'                                                            : LocationData(address=None, content='Ending_B'),
+    'Dawn_Prayer'                                                             : LocationData(address=None, content='Ending_C'),
 }

--- a/worlds/enderlilies/Options.py
+++ b/worlds/enderlilies/Options.py
@@ -50,6 +50,20 @@ class ItemFilterBehavior(Choice):
     option_nothing = 2
     default = option_filler
 
+class VictoryCondition(Choice):
+    """Defines the victory condition for this world.
+
+    ending_a: Acheving ending A trigger a victory. 
+    ending_b: Acheving ending B trigger a victory.
+    ending_c: Acheving ending C trigger a victory.
+    any_ending: Acheving any ending trigger a victory."""
+    display_name = "Victory condition"
+    option_ending_a = 0
+    option_ending_b = 1
+    option_ending_c = 2
+    option_any_ending = 3
+    default = option_ending_c    
+
 el_options: Dict[str, type(Option)] = {
     # # Not added since not sure if the client can read it right now.
     # "shuffle_slots": ShuffleSlots,
@@ -61,6 +75,7 @@ el_options: Dict[str, type(Option)] = {
     # "shuffle_upgrades": ShuffleUpgrades,
     "starting_spirit": StartingSpirit,
     "item_filter_behavior": ItemFilterBehavior,
+    "victory_condition": VictoryCondition,
 }
 
 

--- a/worlds/enderlilies/Rules.py
+++ b/worlds/enderlilies/Rules.py
@@ -774,6 +774,10 @@ def get_rules(p : int) -> Tuple[Dict[str, CollectionRule], Dict[str, ItemRule]]:
 		'Village_16_GAMEPLAY.BP_Interactable_Passives_Treasure_2'                 : lambda s : s.has(el['Village16Right'], p),
 		'Village_16_GAMEPLAY.BP_WorldTravelVolume3'                               : lambda s : s.has(el['Village16Right'], p),
 		'starting_weapon'                                                         : lambda s : True,
+		'Benevolence'                                                             : lambda s : s.has(el['Outside02Left'], p),
+		'Journeys_End'                                                            : lambda s : s.has(el['Abyss03Left'], p),
+		# 'Dawn_Prayer'  dsa                                                            : lambda s : s.has(el['Abyss03Left'], p) and s.has(el['Luminant Aegis Curio'], p),
+		'Dawn_Prayer'                                                             : lambda s : s.has(el['Abyss03Left'], p) and (s.count("Generic.i_FinalPassivePart_Up", p) == 7),
 	}
 
 	items_rules : Dict[str, ItemRule] = {

--- a/worlds/enderlilies/Rules.py
+++ b/worlds/enderlilies/Rules.py
@@ -776,7 +776,6 @@ def get_rules(p : int) -> Tuple[Dict[str, CollectionRule], Dict[str, ItemRule]]:
 		'starting_weapon'                                                         : lambda s : True,
 		'Benevolence'                                                             : lambda s : s.has(el['Outside02Left'], p),
 		'Journeys_End'                                                            : lambda s : s.has(el['Abyss03Left'], p),
-		# 'Dawn_Prayer'  dsa                                                            : lambda s : s.has(el['Abyss03Left'], p) and s.has(el['Luminant Aegis Curio'], p),
 		'Dawn_Prayer'                                                             : lambda s : s.has(el['Abyss03Left'], p) and (s.count("Generic.i_FinalPassivePart_Up", p) == 7),
 	}
 

--- a/worlds/enderlilies/__init__.py
+++ b/worlds/enderlilies/__init__.py
@@ -74,7 +74,8 @@ class EnderLiliesWorld(World):
             add_item_rule(self.multiworld.get_location(name, self.player), rule)
 
         set_rule(self.multiworld.get_location(el['Start'], self.player), lambda state : True)
-        self.multiworld.completion_condition[self.player] = lambda state: state.has(el["Abyss03Left"], self.player)
+
+        self.multiworld.completion_condition[self.player] = get_victory_condition(self.multiworld, self.player)
 
     def generate_output(self, output_directory: str) -> None:
         filename = f"{self.multiworld.get_player_name(self.player)}.EnderLiliesSeed.txt"
@@ -144,3 +145,15 @@ def assign_starting_item(multiworld: MultiWorld, player: int, items) -> str:
     multiworld.get_location('starting_weapon', player).place_locked_item(item)
 
     return spirit_name 
+
+def get_victory_condition(multiworld: MultiWorld, player: int):
+    val = get_option_value(multiworld, player, "victory_condition")
+
+    if val == 0:
+        return lambda state: state.has("Ending_A", player)
+    elif val == 1:
+        return lambda state: state.has("Ending_B", player)
+    elif val == 2:
+        return lambda state: state.has("Ending_C", player)
+    elif val == 3:
+        return lambda state: state.has_any({"Ending_A", "Ending_B", "Ending_C"}, player)


### PR DESCRIPTION
## What is this fixing or adding?
Provide an option to choose which ending will be the victory condition.

## How was this tested?
For each option, five multiworlds were created (EL + another). In all of them, it was confirmed, via the spoiler, that the proposed roadmap goes toward the correct ending. 

With ending C, I confirmed that the 7 stone tablets were considered in the roadmap which was not the case for A and B, as expected.

For some reason, mask and Heal do not appear in the roadmap while they seems required in logic. Not sure why...

This was not tested in-game since the client-side for victory triggering is not available at the moment.

## If this makes graphical changes, please attach screenshots.
None.

## Missing:
We need something to tell the client about the victory condition. If AP does not provide an API to the player's option, we will need to do something more. (I believe it does since it appear in the spoiler, but I am not sure.) 