### PR TITLE
moving to new options api and to self.random

### DIFF
--- a/worlds/enderlilies/Options.py
+++ b/worlds/enderlilies/Options.py
@@ -1,7 +1,8 @@
 from worlds.AutoWorld import World
 from BaseClasses import Item, Location, Dict
 from typing import Dict, Tuple, Type, List
-from Options import Choice, Option, DefaultOnToggle, Toggle, Range
+from dataclasses import dataclass
+from Options import Choice, Option, DefaultOnToggle, Toggle, Range, PerGameCommonOptions
 from .Names import names as el
 from .StartingLocations import startingLocationsData
 
@@ -12,7 +13,7 @@ def option(name: str):
 
     @classmethod
     def get_option(cls, world: World) -> Option:
-        return getattr(world.multiworld, cls.name)[world.player]
+        return getattr(world, cls.name)
 
     def decorator(cls: Type[Option]) -> Type[Option]:
         cls.name = name
@@ -324,3 +325,24 @@ class RandomizeEntrances(Toggle):
     default: Off"""
 
     display_name = "Randomize Entrances"
+
+
+@dataclass
+class EnderLiliesGameOptions(PerGameCommonOptions):
+    starting_spirit: StartingSpirit
+    starting_location: StartingLocation
+    item_pool_priority: ItemPoolPriority
+    goal: Goal
+    early_maneuver: EarlyManeuver
+    shuffle_slots: ShuffleRelicsCosts
+    minibosses_chapter: SubSpiritsIncreaseChapter
+    ng_plus: NewGamePlusAI
+    shuffle_upgrades: ShuffleSpiritsUpgrades
+    force_ancient_souls: StartingWeaponUsesAncientSouls
+    shuffle_bgm: ShuffleBGM
+    start_chapter: ChapterMin
+    max_chapter: ChapterMax
+    stone_tablets_placement: StoneTabletsPlacement
+    add_unused_items: AddUnusedItems
+    # dash_before_lance: DashBeforeLance
+    entrance_randomizer: RandomizeEntrances

--- a/worlds/enderlilies/__init__.py
+++ b/worlds/enderlilies/__init__.py
@@ -81,7 +81,7 @@ class EnderLiliesWorld(World):
             maneuver_items = early_maneuver_opt.get_early_maneuver(
                                                       self.get_option(StartingLocation))
             if early_maneuver_opt.value == 1:
-                non_local_items = self.non_local_items.value
+                non_local_items = self.options.non_local_items.value
                 avail_local_maneuver = [item for item in maneuver_items 
                                           if item not in non_local_items]
                 item_name = self.random.choice(avail_local_maneuver)

--- a/worlds/enderlilies/__init__.py
+++ b/worlds/enderlilies/__init__.py
@@ -66,7 +66,9 @@ class EnderLiliesWorld(World):
 
     game = ENDERLILIES
     web = EnderLiliesWeb()
-    option_definitions = options
+    # option_definitions = options
+    options_dataclass = EnderLiliesGameOptions
+    options: EnderLiliesGameOptions
     location_name_to_id = {name: data.address for name, data in locations.items()}
     item_name_to_id = {name: data.code for name, data in items.items()}
     
@@ -79,13 +81,13 @@ class EnderLiliesWorld(World):
             maneuver_items = early_maneuver_opt.get_early_maneuver(
                                                       self.get_option(StartingLocation))
             if early_maneuver_opt.value == 1:
-                non_local_items = self.multiworld.non_local_items[self.player].value
+                non_local_items = self.non_local_items.value
                 avail_local_maneuver = [item for item in maneuver_items 
                                           if item not in non_local_items]
-                item_name = self.multiworld.random.choice(avail_local_maneuver)
+                item_name = self.random.choice(avail_local_maneuver)
                 self.multiworld.local_early_items[self.player][item_name] = 1
             elif early_maneuver_opt.value == 2:
-                item_name = self.multiworld.random.choice(maneuver_items)
+                item_name = self.random.choice(maneuver_items)
                 self.multiworld.early_items[self.player][item_name] = 1
 
     def create_item(self, item: str) -> EnderLiliesItem:
@@ -105,7 +107,7 @@ class EnderLiliesWorld(World):
             for i in range(data.count):
                 pool.append(self.create_item(item))
         unfilled_location = self.multiworld.get_unfilled_locations(self.player)
-        self.multiworld.random.shuffle(pool)
+        self.random.shuffle(pool)
         pool : List[EnderLiliesItem] = self.get_option(ItemPoolPriority).sort_items_list(pool, len(unfilled_location))
 
         if self.get_option(StoneTabletsPlacement).value == StoneTabletsPlacement.option_region:
@@ -124,7 +126,7 @@ class EnderLiliesWorld(World):
         if self.get_option(RandomizeEntrances):
             er = EntranceRandomizer(starting_location)
             portals = er.get_portals()
-            self.multiworld.random.shuffle(portals)
+            self.random.shuffle(portals)
             self.randomized_entrances = er.Randomize(portals)
         connections : List[Tuple[Region, str, str]] = []
 
@@ -175,7 +177,7 @@ class EnderLiliesWorld(World):
             tablets_locations : List[Location]  = self.multiworld.find_item_locations(el["tablet"], self.player)
             tablet : EnderLiliesItem = tablets_locations[0].item
             valid_locations : List[Location]  = [location for location in self.multiworld.get_locations(self.player) if not location.locked and location.can_fill(self.multiworld.state, tablet) and location.item == None or not location.item.advancement]
-            self.multiworld.random.shuffle(valid_locations)
+            self.random.shuffle(valid_locations)
             swaps : List[Tuple[Location, Location]] = StoneTabletsPlacement.place_tablets_in_regions(tablets_locations, valid_locations)
             for swap in swaps:
                 swap_location_item(swap[0], swap[1], True)
@@ -245,11 +247,11 @@ class EnderLiliesWorld(World):
         return slot_data
 
     def get_option(self, option: Union[str, Type[Option]]) -> Option:
-        if self.multiworld is None:
-            return option.default
+        # if self.multiworld is None:
+        #     return option.default
         if isinstance(option, str):
-            return self.multiworld.__getattribute__(option)[self.player]
-        return self.multiworld.__getattribute__(option.name)[self.player]
+            return self.options.__getattribute__(option)
+        return self.options.__getattribute__(option.name)
 
     def get_filler_item_name(self) -> str:
         return "nothing"
@@ -257,7 +259,7 @@ class EnderLiliesWorld(World):
     def assign_starting_items(self) -> List[str]:
         weapon_name = self.get_option(StartingSpirit).get_starting_weapon_pool()
         if isinstance(weapon_name, list):
-            weapon_name = self.multiworld.random.choice(weapon_name)
+            weapon_name = self.random.choice(weapon_name)
         starting_weapon = self.create_item(weapon_name)
         self.multiworld.get_location("Starting Spirit", self.player).place_locked_item(starting_weapon)
         return [weapon_name]


### PR DESCRIPTION
## What is this fixing or adding?
moving to new options api and to self.random

## How was this tested?
manually grabbing the different options in a python shell and confirming they could be used as expected
running a couple generations on different settings and confirming they generated 
and generating the yaml template for the current apworld and for this branch and confirming no changes to option names/etc.

## If this makes graphical changes, please attach screenshots.

## Notes:
One note and a couple things from my inadvertent review
with the new options api you shouldn't have to import * on Options.py because this
`self.get_option(StoneTabletsPlacement).value == StoneTabletsPlacement.option_region`
can be this instead
`self.options.stone_tablets_placement == "region"`
(or like these keeping the get_options helper)
`self.get_option(StoneTabletsPlacement) == "region"`
`self.get_option("stone_tablets_placement") == "region"`

but since that is mostly a style thing, i'll leave it up to you how you want to grab the options.


and the little review notes:

you should be using location scouts instead of adding all location metadata to slot_data; it's just a hint you don't tell the players about.
https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#locationscouts
ideally, scout everything once, save along with the savefile etc. and read from local on relaunch/connects. it means a bit more thinking on the client-side, but you'll get this suggestion sooner or later.

create_item() defaulting to an event if the name is unknown is a bit worrysome without a proper filler name. But if you make get_filler_item_name return real item names (that there wouldn't be a problem if there were infinite of) I don't think create_items() working like that will be an issue.

i'm not the biggest fan of recreating a mini-swap for 'region' stone tablets, i'd suggest you place and lock them before fill instead. But I can only really see the current functionality being a problem if you somehow managed to not have any swappable locations in a map region after fill etc. so its probably not a *big* issue.